### PR TITLE
Ensure it's obvious when a command fails

### DIFF
--- a/root/exec_travis_scripts.rb
+++ b/root/exec_travis_scripts.rb
@@ -5,5 +5,6 @@ travis_yml = YAML.load_file('.travis.yml')
 travis_yml["script"].each do |x|
   puts "Executing: #{x}"
   system(x)
+  puts "Command exit code #{$?.exitcode}"
 end
 


### PR DESCRIPTION
It wasn't clear to me (maybe it should have been!) that getting a warning from puppet-lint would be fatal in travisci, so this patch displays the return code from `system()`